### PR TITLE
missing comma at Launcher.py:155

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -152,7 +152,7 @@ components: Iterable[Component] = (
     # Starcraft 2
     Component('Starcraft 2 Client', 'Starcraft2Client'),
     # The Legend of Zelda
-    Component('The Legend of Zelda Client', 'Zelda1Client')
+    Component('The Legend of Zelda Client', 'Zelda1Client'),
     # Zillion
     Component('Zillion Client', 'ZillionClient',
               file_identifier=SuffixIdentifier('.apzl')),


### PR DESCRIPTION
Missing comma causing build syntax error.

## What is this fixing or adding?
Missing comma preventing setup.py build

## How was this tested?
It was throwing a syntax error before. Not it isn't.

