### PR TITLE
Update __init__.py so characters case insensitive

### DIFF
--- a/worlds/ff6wc/__init__.py
+++ b/worlds/ff6wc/__init__.py
@@ -95,17 +95,17 @@ class FF6WCWorld(World):
 
     def generate_early(self):
         starting_characters = [
-            self.multiworld.StartingCharacter1[self.player].current_key,
-            self.multiworld.StartingCharacter2[self.player].current_key,
-            self.multiworld.StartingCharacter3[self.player].current_key,
-            self.multiworld.StartingCharacter4[self.player].current_key
+            (self.multiworld.StartingCharacter1[self.player].current_key).capitalize(),
+            (self.multiworld.StartingCharacter2[self.player].current_key).capitalize(),
+            (self.multiworld.StartingCharacter3[self.player].current_key).capitalize(),
+            (self.multiworld.StartingCharacter4[self.player].current_key).capitalize()
         ]
         starting_characters = starting_characters[0:self.multiworld.StartingCharacterCount[self.player]]
-        starting_characters.sort(key=lambda character: character == "random_with_no_gogo_or_umaro")
+        starting_characters.sort(key=lambda character: character == "Random_with_no_gogo_or_umaro")
 
         filtered_starting_characters = []
         for character in starting_characters:
-            if character == "random_with_no_gogo_or_umaro":
+            if character == "Random_with_no_gogo_or_umaro":
                 character = random.choice(Rom.characters[:12])
                 while character in filtered_starting_characters:
                     character = random.choice(Rom.characters[:12])


### PR DESCRIPTION
WebHost produces yamls with low cased character names (e.g. celes, shadow, locke); but the expected values from the array are Celes, Shadow, Locke. capitalize() the input so case is insensitive. Change expected value "random_with_no_gogo_or_umaro" to "Random_with_no_gogo_or_umaro" to handle the capitalize()d input.

## What is this fixing or adding?
WebHost and handwritten Yamls containing "celes" would fail on generate, but if you change input to "Celes" it works. All character streams are now formatted this way, but the WebHosts produces lowercase answers, and users may not know they need it formatted just so.

## How was this tested?
Tested yamls with multiple inputs: "celes", "Celes", "ceLES", "random", and "random_with_no_goGo_or_umaro". All of these inputs worked when generated.