### PR TITLE
Wrexsoul crash

### DIFF
--- a/worlds/ff6wc/Locations.py
+++ b/worlds/ff6wc/Locations.py
@@ -555,7 +555,7 @@ item_only_checks = list(dragons)
 item_only_checks.extend(["Lone Wolf 2", "Narshe Weapon Shop 2", "Gem Box", "Atma"])
 item_only_checks.extend(minor_ext_checks)
 item_only_checks.extend(minor_checks)
-no_item_checks = ["Cranes", "MagiMaster", "Imperial Air Force", "Nerapa", "Veldt"]
-no_character_checks = ["Auction House 10kGP", "Auction House 20kGP", "Wrexsoul", "Doma Castle Throne",
+no_item_checks = ["Cranes", "MagiMaster", "Imperial Air Force", "Nerapa", "Veldt", "Wrexsoul"]
+no_character_checks = ["Auction House 10kGP", "Auction House 20kGP", "Doma Castle Throne",
                        "Doom Gaze", "AtmaWeapon", "Ifrit and Shiva", "Number 024", "Narshe Weapon Shop 1",
                        "Tritoch", "Tzen Thief"]

--- a/worlds/ff6wc/Locations.py
+++ b/worlds/ff6wc/Locations.py
@@ -557,5 +557,5 @@ item_only_checks.extend(minor_ext_checks)
 item_only_checks.extend(minor_checks)
 no_item_checks = ["Cranes", "MagiMaster", "Imperial Air Force", "Nerapa", "Veldt", "Wrexsoul"]
 no_character_checks = ["Auction House 10kGP", "Auction House 20kGP", "Doma Castle Throne",
-                       "Doom Gaze", "AtmaWeapon", "Ifrit and Shiva", "Number 024", "Narshe Weapon Shop 1",
+                       "Doom Gaze", "Dream Stooges", "AtmaWeapon", "Ifrit and Shiva", "Number 024", "Narshe Weapon Shop 1",
                        "Tritoch", "Tzen Thief"]


### PR DESCRIPTION
Per https://wiki.ff6worldscollide.com/wiki/Checks#Cyan's_Dream Wrexsoul must give an esper or character... If it tries to give you an item, you'll get a black screen crash after the boss battle.