### PR TITLE
Fix and improve item pool generation

### DIFF
--- a/worlds/ff6wc/Locations.py
+++ b/worlds/ff6wc/Locations.py
@@ -592,7 +592,6 @@ dragons = ["Red Dragon", "Storm Dragon", "Blue Dragon", "Dirt Dragon",
 # Except for Cranes, Magimaster, Imperial Air Force, AtmaWeapon, Veldt
 # Most are the first one, so we only need to note the exceptions
 item_only_checks = [*dragons, "Lone Wolf 2", "Narshe Weapon Shop 2"]
-no_item_checks = []
 no_character_checks = ["Auction House 10kGP", "Auction House 20kGP", "Dream Stooges",
                        "AtmaWeapon", "Ifrit and Shiva", "Number 024",
                         "Tzen Thief"]


### PR DESCRIPTION
## What is this fixing or adding?
With Treasuresanity off, 148 items are being generated for 62 locations. This code fixes this as well as simplifies the whole process of generating the item pool. 

`no_item_checks` and code for handling it was entirely removed as it is a blank list.

## How was this tested?
Generating and observing correct number of items being generated.