### PR TITLE
fixed random character generation with custom flagstring

### DIFF
--- a/worlds/ff6wc/__init__.py
+++ b/worlds/ff6wc/__init__.py
@@ -117,7 +117,7 @@ class FF6WCWorld(World):
                 character_list.append(flags_list[sc4_index])
 
             for character in range(len(character_list)):
-                if character_list[character] == "randomgu":
+                if character_list[character] == "randomngu":
                     compare_character_list = character_list.copy()
                     character_list[character] = random.choice(Rom.characters[:12]).lower()
                     while character_list[character] in compare_character_list:


### PR DESCRIPTION
fixed typo in "randomgu" to "randomngu". This typo is currently affecting generation success when a custom flagstring is used and the player is attempting to select random starting characters (no goog/umaro).