### PR TITLE
Fix Generation Issues for Item Restrictions and Treasuresanity

### DIFF
--- a/worlds/ff6wc/__init__.py
+++ b/worlds/ff6wc/__init__.py
@@ -337,13 +337,21 @@ class FF6WCWorld(World):
                 filler_pool.append(item)
             if item in Items.good_items:
                 good_filler_pool.append(item)
-        major_items = len([location for location in Locations.major_checks if "(Boss)" not in location and "Status" not
-                           in location]) - len(item_pool)
 
-        for _ in range(major_items):
-            item_pool.append(self.create_good_filler_item(self.multiworld.random.choice(good_filler_pool)))
-        if self.multiworld.Treasuresanity[self.player]:
-            minor_items = len(Locations.all_minor_checks)
+        major_items = len([location for location in Locations.major_checks if "(Boss)" not in location and "Status"
+                            not in location])
+        progression_items = len(item_pool)
+        if not self.multiworld.Treasuresanity[self.player]:
+            major_items = major_items - progression_items
+            for _ in range(major_items):
+                item_pool.append(self.create_good_filler_item(self.multiworld.random.choice(good_filler_pool)))
+            self.multiworld.itempool += item_pool
+        # Note that for stability in generation and simplicity, this method generates an excess of good items in
+        # Treasuresanity seeds due to not knowing which minor checks have been selected to have characters or espers.
+        else:
+            for _ in range(major_items):
+                item_pool.append(self.create_good_filler_item(self.multiworld.random.choice(good_filler_pool)))
+            minor_items = len(Locations.all_minor_checks) - progression_items
             for _ in range(minor_items):
                 item_pool.append(self.create_filler_item(self.multiworld.random.choice(filler_pool)))
             self.multiworld.itempool += item_pool

--- a/worlds/ff6wc/__init__.py
+++ b/worlds/ff6wc/__init__.py
@@ -9,7 +9,6 @@ import threading
 from typing import NamedTuple, Union
 import logging
 
-import BaseClasses
 from BaseClasses import Item, Location, Region, Entrance, MultiWorld, ItemClassification
 from . import Logic
 from .Rom import FF6WCDeltaPatch
@@ -36,7 +35,6 @@ class FF6WCWorld(World):
     base_id = 6000
     web = FF6WCWeb()
     wc_ready = threading.Lock()
-    modified_item_table = item_table
     item_name_to_id = {name: index for index, name in enumerate(item_table)}
     location_name_to_id = {name: index for index, name in enumerate(location_table)}
 
@@ -496,9 +494,7 @@ class FF6WCWorld(World):
         wc_args = ["-i", "Final Fantasy III (USA).sfc", "-o", f"{output_file}", "-ap", placement_file]
         wc_args.extend(generate_flagstring(self.multiworld, self.player, self.starting_characters))
         print(wc_args)
-        self.generator_in_use.set()
-        with self.wc_ready:
-            self.generator_in_use.wait()
+        with FF6WCWorld.wc_ready:
             import sys
             from copy import deepcopy
             module_keys = deepcopy(list(sys.modules.keys()))
@@ -516,7 +512,7 @@ class FF6WCWorld(World):
             os.remove(output_file)
             os.remove(placement_file)
             self.rom_name_available_event.set()
-        self.generator_in_use.clear()
+
     def modify_multidata(self, multidata: dict):
         import base64
         # wait for self.rom_name to be available.


### PR DESCRIPTION
Allows generation with AllowStrongestItems off restrictions with WebHost generated yamls and "-nfps", "-nil", and "-nee" item restrictions with custom flagstrings enabled.

Also now generates enough good items in a treasuresanity seed to ensure that all major check locations will have access to characters, espers, and good items.

Note: Some unintentional changes were pushed with the second commit. Following commits are the attempt to roll back and revert the unintentionally pushed changes. Apologies for this.