### PR TITLE
Remove EnableFlagstring variable

### DIFF
--- a/worlds/ff6wc/Options.py
+++ b/worlds/ff6wc/Options.py
@@ -262,15 +262,10 @@ class Treasuresanity(Choice):
     option_on = 1
     option_on_with_additional_gating = 2
 
-class EnableFlagstring(FreeText):
-    """Enables the Flagstring option. Set this to "true" to use a custom Worlds Collide flagstring"""
-    display_name = "Enable Flagstring"
-    default = "false"
-
 class Flagstring(FreeText):
-    """Custom flagstring. For advanced users only: will override most other options"""
+    """Enables custom flagstring. For advanced users only: will override most other options"""
     display_name = "Flagstring"
-    default = "flagstring_here"
+    default = "False"
 
 ff6wc_options: typing.Dict[str, type(Option)] = {
     "CharacterCount": CharacterCount,
@@ -298,12 +293,12 @@ ff6wc_options: typing.Dict[str, type(Option)] = {
     "AllowStrongestItems": AllowStrongestItems,
     "RandomizeZozoClock": RandomizeZozoClock,
     "Treasuresanity": Treasuresanity,
-    "EnableFlagstring": EnableFlagstring,
     "Flagstring": Flagstring
 }
 
 def generate_flagstring(multiworld: MultiWorld, player: int, starting_characters):
-    if multiworld.EnableFlagstring[player].value == 'true':
+    
+    if (multiworld.Flagstring[player].value).capitalize() != 'False':
         flags = multiworld.Flagstring[player].value.split(" ")
     else:
         flags = [

--- a/worlds/ff6wc/__init__.py
+++ b/worlds/ff6wc/__init__.py
@@ -99,8 +99,7 @@ class FF6WCWorld(World):
         return return_location
 
     def generate_early(self):
-        if self.multiworld.EnableFlagstring[self.player].value == "true":
-
+        if (self.multiworld.Flagstring[self.player].value).capitalize() != "False":
             self.starting_characters = []
             character_list = []
             flags = self.multiworld.Flagstring[self.player].value
@@ -291,7 +290,7 @@ class FF6WCWorld(World):
 
     def create_items(self):
         # Setting variables for item restrictions based on custom flagstring or AllowStrongestItems value
-        if self.multiworld.EnableFlagstring[self.player]:
+        if (self.multiworld.Flagstring[self.player].value).capitalize() != "False":
             if "-nfps" in self.multiworld.Flagstring[self.player].value.split(" "):
                 self.no_paladin_shields = True
             if "-nee" in self.multiworld.Flagstring[self.player].value.split(" "):


### PR DESCRIPTION
## What is this fixing or adding?
Remove the EnableFlagstring option. Instead, just use Flagstring. Flagstring default is changed to "False". If Flagstring is in the yaml and it isn't "False", use that FreeText as the Flagstring option. We should not need two options for this. Also ensure case doesn't matter for "False".

## How was this tested?
Locally generating seeds with the changes in place.
