### PR TITLE
Address non-sequential "-sc#" input flags (resubmission)

### DIFF
--- a/worlds/ff6wc/__init__.py
+++ b/worlds/ff6wc/__init__.py
@@ -105,8 +105,9 @@ class FF6WCWorld(World):
             flags = self.multiworld.Flagstring[self.player].value
             # Determining Starting Characters
             flags_list = flags.split(" ")
-            sc1_index = flags_list.index("-sc1") + 1
-            character_list.append(flags_list[sc1_index])
+            if "-sc1" in flags_list:
+                sc1_index = flags_list.index("-sc1") + 1
+                character_list.append(flags_list[sc1_index])
             if "-sc2" in flags_list:
                 sc2_index = flags_list.index("-sc2") + 1
                 character_list.append(flags_list[sc2_index])
@@ -131,15 +132,19 @@ class FF6WCWorld(World):
                 elif character_list[character] not in character_list:
                     character_list[character] = character_list[character]
 
-            for x in range(len(character_list)):
-                if x == 0:
-                    flags_list[sc1_index] = character_list[x]
-                if x == 1:
-                    flags_list[sc2_index] = character_list[x]
-                if x == 2:
-                    flags_list[sc3_index] = character_list[x]
-                if x == 3:
-                    flags_list[sc4_index] = character_list[x]
+            x = 0
+            if sc1_index != 0:
+                flags_list[sc1_index] = character_list[x]
+                x += 1
+            if sc2_index != 0:
+                flags_list[sc2_index] = character_list[x]
+                x += 1
+            if sc3_index != 0:
+                flags_list[sc3_index] = character_list[x]
+                x += 1
+            if sc4_index != 0:
+                flags_list[sc4_index] = character_list[x]
+                x += 1
 
             self.multiworld.StartingCharacterCount[self.player].value = len(character_list)
             starting_character_options = list(self.multiworld.StartingCharacter1[self.player].name_lookup.values())


### PR DESCRIPTION
Allows for flagstring inputs which don't sequentially define the characters in the flagstring starting with -sc1, -sc2, etc. It is possible/easy to generate a single character flagstring which defines that character by the -sc4 flag while not defining and of the previous starting character flags. Existing code cannot handle this situation. Fix is to address this.

Replacement PR for https://github.com/Rosalie-A/Archipelago/pull/37

Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?


## How was this tested?


## If this makes graphical changes, please attach screenshots.
