### PR TITLE
Fix bug from PR #44

### DIFF
--- a/worlds/ff6wc/__init__.py
+++ b/worlds/ff6wc/__init__.py
@@ -105,6 +105,7 @@ class FF6WCWorld(World):
             flags = self.multiworld.Flagstring[self.player].value
             # Determining Starting Characters
             flags_list = flags.split(" ")
+            sc1_index = sc2_index = sc3_index = sc4_index = 0
             if "-sc1" in flags_list:
                 sc1_index = flags_list.index("-sc1") + 1
                 character_list.append(flags_list[sc1_index])


### PR DESCRIPTION
https://github.com/Rosalie-A/Archipelago/pull/44 was intended to fixed the ability to input custom flagstrings, however indroduced an error due to variables for starting character indices not being declared before their use. This fixes that by setting variables to the value of '0' before they are modified and checked.