### PR TITLE
Fusion locations.py: Contributing KickClimbs and some SJ related fixes

### DIFF
--- a/worlds/metroidfusion/data/locations.py
+++ b/worlds/metroidfusion/data/locations.py
@@ -135,7 +135,6 @@ class CanDoTrickyShinespark(Requirement):
     def check_option_enabled(options: "MetroidFusionOptions") -> bool:
         return bool(options.TrickyShinesparksInRegionLogic.value)
 
-
 class CanDoSimpleWallJump(Requirement):
     items_needed = []
 
@@ -157,6 +156,12 @@ class CanDoSimpleWallJumpWithScrewAttack(Requirement):
     def check_option_enabled(options: "MetroidFusionOptions") -> bool:
         return bool(options.SimpleWallJumpsInRegionLogic.value)
 
+class CanDoTrickyWallJump(Requirement):
+    items_needed = []
+
+    @staticmethod
+    def check_option_enabled(options: "MetroidFusionOptions") -> bool:
+        return bool(options.TrickyWallJumpsInRegionLogic.value)
 
 class SectorHubLevel1KeycardRequirement(Requirement):
     items_needed = ["Level 1 Keycard"]
@@ -793,8 +798,8 @@ class Sector5TubeRight(FusionRegion):
 class Sector5MagicBox(FusionRegion):
     name = "Sector 5 Magic Box"
 
-class Sector5TopleftBigRoom(FusionRegion):
-    name = "Sector 5 Big Room"
+class Sector5TopLeftBigRoom(FusionRegion):
+    name = "Sector 5 Top Left of Big Room"
 
 class Sector5FrozenHub(FusionRegion):
     name = "Sector 5 Frozen Hub"
@@ -1564,7 +1569,7 @@ Sector5Hub.connections = [
     Connection(Sector5MagicBox, [
         Level3KeycardRequirement([], [])
     ]),
-    Connection(Sector5TopleftBigRoom, [
+    Connection(Sector5TopLeftBigRoom, [
         Level3KeycardRequirement([], [CanJumpHigh, CanDoTrickyWallJump]),
         Requirement(["Morph Ball"], [HasMissile])
     ]),
@@ -1583,7 +1588,7 @@ Sector5TubeRight.connections = [
     Connection(Sector5BeforeNightmareHub, [], one_way=True)
 ]
 
-Sector5TopleftBigRoom.connections = [
+Sector5TopLeftBigRoom.connections = [
     Connection(Sector5FrozenHub, [HasVaria], one_way=True)
 ]
 
@@ -1596,7 +1601,7 @@ Sector5FrozenHub.connections = [
         Requirement(["Speed Booster"], [CanBombOrPowerBomb]),
         Level3KeycardRequirement([], [HasWaveBeam])
     ], one_way=True),
-    Connection(Sector5TopleftBigRoom, [CanJumpHigh, CanDoTrickyWallJump]
+    Connection(Sector5TopLeftBigRoom, [CanJumpHigh, CanDoTrickyWallJump]
 ]
 
 Sector5SecurityZone.connections = [
@@ -1654,7 +1659,7 @@ Sector5MagicBox.locations = [
     FusionLocation("Sector 5 (ARC) -- Magic Box", False, [])
 ]
 
-Sector5BigRoom.locations = [
+Sector5TopLeftBigRoom.locations = [
     FusionLocation("Sector 5 (ARC) -- Training Aerie -- Left Item", False, [
         Requirement(["Speed Booster"], [HasSpaceJump, CanFreezeEnemies])
     ]),
@@ -1931,7 +1936,7 @@ fusion_regions: list[FusionRegion] = [
     Sector5TubeLeft,
     Sector5TubeRight,
     Sector5MagicBox,
-    Sector5TopleftBigRoom,
+    Sector5TopLeftBigRoom,
     Sector5FrozenHub,
     Sector5SecurityZone,
     Sector5DataRoom,


### PR DESCRIPTION
I'd gone through and added "CanDoKickClimbs" all over the place, accidentally sent the pull request to myself, and noticed the next morning you had already been adding the option yourself. XD But I also added some more spots to use it. Also added some Tricky ones in case that's a later option.

Also I modified some connections and locations that looked a little incomplete or bugged:
- Big Room in 5 seems to have a similar bug as MFOR (I think) did. There's no enemy you can freeze to get up from the very bottom, but you can technically kick off the door to barely make it high enough to kick again to get up. This might need revising later, once a tricky shinespark is added there.
- Added freezing enemies to TRO kago room.
- PYR Hub to Attic required morphing through the tunnel, or uh, missiling the tunnel in frustration? Unless there's another connection besides Lobby, that's a morph transition.
- Added Varia from left tube to hub. Although, maybe the items should be moved?
- Added Serris entry and exit via Gravity, although, I feel like it's unnecessary to route backtracking. I guess the idea had been to eventually access Vault from Serris instead of UpperZone? Also SJ added as means to reach arena ladder.
- Added SJ as an option to Nightmare Hub entry requirements, from both Before and 4fore. Also kinda future proofed in case it's ever a starting location.
- Added ice tutorial path from 5 security.
- Added access to minifridge from ground. You can do the room itself mostly unmorphed and just climb ledges, funny enough.
- Post XBOX probably has a tricky jump, but eh, just added a simple and some frozen enemies and am le tired.