### PR TITLE
Fusion logic: Sector6.py: Clogged Cavern PONR fix

### DIFF
--- a/worlds/metroidfusion/data/logic/topologies/Sector6.py
+++ b/worlds/metroidfusion/data/logic/topologies/Sector6.py
@@ -32,7 +32,10 @@ Sector6Crossroads.connections = [
     ]),
     Connection(Sector6BeforeVariaCoreXZone, [
         PONRRequirement(["Speed Booster"], [CanBombOrPowerBomb]),
-        Requirement(["Speed Booster", "Power Bomb Data", "Space Jump"], [
+        CanDoAdvancedShinesparkRequirement(["Morph Ball", "Power Bomb Data"], [
+            HasSpaceJump, CanDoAdvancedWalljump
+        ]),
+        Level2KeycardRequirement(["Speed Booster", "Charge Beam", "Missile Data", "Varia Suit"], [
             CanBombOrPowerBomb
         ])
     ]),
@@ -96,7 +99,13 @@ Sector6Hub.locations = [
 ]
 
 Sector6Crossroads.locations = [
-    FusionLocation("Sector 6 (NOC) -- Catacombs", False, [HasSpeedBooster]),
+    FusionLocation("Sector 6 (NOC) -- Catacombs", False, [
+        PONRRequirement([HasSpeedBooster]),
+        CanDoAdvancedShinesparkRequirement([]),
+        Level2KeycardRequirement(["Speed Booster", "Charge Beam", "Missile Data", "Varia Suit"], [
+            CanBombOrPowerBomb
+        ])
+    ]),
     FusionLocation("Sector 6 (NOC) -- Missile Mimic Lodge", False, [
         Requirement(["Varia Suit"], [CanBombOrPowerBomb])
     ]),


### PR DESCRIPTION
Speed blocks pre-core are easy to break through going in, but pretty tricky to break out to leave. Added PONR, Advanced Shinespark, and full loop requirements to Catacombs and connection from Crossroads to BeforeVariaCore.

They're also a lot easier to get past after they stop existing once the core's defeated, but there's gotta be some intel option before accounting for that.