### PR TITLE
Fusion Locations.py: shinesparklocations update

### DIFF
--- a/worlds/metroidfusion/Locations.py
+++ b/worlds/metroidfusion/Locations.py
@@ -107,12 +107,10 @@ for region in fusion_regions:
 
 
 difficult_speed_booster_list = [
+    "Sector 1 (SRX) -- Charge Core Arena -- Upper Item",
+    "Sector 1 (SRX) -- Watering Hole",
     "Sector 2 (TRO) -- Zazabi Speedway -- Lower Item",
     "Sector 2 (TRO) -- Zazabi Speedway -- Upper Item",
-    "Sector 3 (PYR) -- Fiery Storage -- Upper Item",
-    "Sector 3 (PYR) -- Deserted Runway",
-    "Sector 3 (PYR) -- Garbage Chute -- Lower Item",
-    "Sector 3 (PYR) -- Garbage Chute -- Upper Item",
     "Sector 6 (NOC) -- Spaceboost Alley -- Lower Item",
     "Sector 6 (NOC) -- Spaceboost Alley -- Upper Item",
     "Main Deck -- Restricted Airlock"


### PR DESCRIPTION
Added both sparks near Charge Core, but the PYR locations felt too simple, unless Training Aerie, 5 to 4 connector, and pillar party are included.
