### PR TITLE
Fusion logic: MainDeck.py requirements fix

### DIFF
--- a/worlds/metroidfusion/data/logic/topologies/MainDeck.py
+++ b/worlds/metroidfusion/data/logic/topologies/MainDeck.py
@@ -47,7 +47,15 @@ OperationsDeckElevatorTop.connections = [
 ]
 
 OperationsDeck.connections = [
-    Connection(LowerArachnusArena, [HasMissile], one_way=True)
+    Connection(VentilationZone, [HasMissile], one_way=True)
+]
+
+UpperArachnusArena.connections = [
+    Connection(LowerArachnusArena, [
+        PONRRequirement([], [HasMissile]),
+        CanBeatToughEnemyRequirement(["Morph Ball"], [CanDefeatSmallGeron]),
+        CanMorphRequirement(["Screw Attack"], [CanJumpHigh, CanDoSimpleWallJump])
+    ], one_way=True)
 ]
 
 HabitationDeckElevatorBottom.connections = [


### PR DESCRIPTION
Requirement tags missing "requirement", causing them to be options amidst other options, instead of requirement trees.