### PR TITLE
Adds ability to configure filler items as part of custom game mode.

### DIFF
--- a/worlds/metroidfusion/Options.py
+++ b/worlds/metroidfusion/Options.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 from Options import Toggle, Range, Choice, PerGameCommonOptions, DefaultOnToggle, StartInventoryPool, OptionGroup, \
-    DeathLink, Removed
+    ItemSet, DeathLink, Removed
 
 
 # Main Options
@@ -123,7 +123,7 @@ class StartingMajorUpgrades(Range):
     """How many major upgrades you begin with.
     Note that depending on your StartingLocation and EarlyProgression settings, you may receive more than specified here
     in order to successfully generate the game. Upgrades are taken from the general item pool and will be replaced
-    by a random minor tank.
+    by a random filler item.
     These will be applied in addition to your start_inventory and start_inventory_from_pool items.
     These will be sent by the client once you're connected.
     This is a Custom Game Mode option and will only be applied if GameMode is set to Custom."""
@@ -135,13 +135,21 @@ class StartingMajorUpgrades(Range):
 class StartingEnergyTanks(Range):
     """How many Energy Tanks you begin with.
     This will be overridden by the number specified in start_inventory and start_inventory_from_pool, if applicable.
-    Energy tanks are taken from the general item pool and will be replaced by a random minor tank.
+    Energy tanks are taken from the general item pool and will be replaced by a random filler item.
     These will be sent by the client once you're connected.
     This is a Custom Game Mode option and will only be applied if GameMode is set to Custom."""
     display_name = "Starting Energy Tanks"
     range_start = 0
     range_end = 20
     default = 0
+
+class FillerItems(ItemSet):
+    """Which Items are used as filler when Items are removed from the pool
+    Whenever an item is removed from the pool by start_inventory_from_pool, StartingMajorUpgrades, StartingEnergyTanks,
+    or for other reasons, it will be replaced with a random item from this list.
+    This is a Custom Game Mode option and will only be applied if GameMode is set to Custom."""
+    display_name = "Filler Items"
+    default = ["Missile Tank", "Power Bomb Tank"]
 
 class OpenSectorElevators(Toggle):
     """Determines if the sector elevators in the Sector Hub are locked by their vanilla keycard requirements.
@@ -243,6 +251,7 @@ class MetroidFusionOptions(PerGameCommonOptions):
     StartingLocation: StartingLocation
     StartingMajorUpgrades: StartingMajorUpgrades
     StartingEnergyTanks: StartingEnergyTanks
+    FillerItems: FillerItems
     OpenSectorElevators: OpenSectorElevators
     SectorNavigationRoomHintLocks: SectorNavigationRoomHintLocks
 
@@ -283,6 +292,7 @@ metroid_fusion_option_groups = [
         StartingLocation,
         StartingMajorUpgrades,
         StartingEnergyTanks,
+        FillerItems,
         OpenSectorElevators,
         SectorNavigationRoomHintLocks
     ]),

--- a/worlds/metroidfusion/__init__.py
+++ b/worlds/metroidfusion/__init__.py
@@ -103,6 +103,7 @@ class MetroidFusionWorld(World):
     starting_region: Region
     starting_major_upgrades: int = 0
     starting_energy_tanks: int = 0
+    filler_items: list[str] = None
     open_sector_elevators: bool = False
     navigation_room_hint_locks: bool = False
 
@@ -126,7 +127,6 @@ class MetroidFusionWorld(World):
 
     def __init__(self, multiworld: MultiWorld, player: int):
         super().__init__(multiworld, player)
-        self.filler_items = None
         self.hint_text = None
         self.hint_pairs = None
         self.region_map = dict()
@@ -154,6 +154,7 @@ class MetroidFusionWorld(World):
                 self.starting_location_object = main_deck_hub
             self.starting_major_upgrades = 0
             self.starting_energy_tanks = 0
+            self.filler_items = None
             self.open_sector_elevators = False
             self.navigation_room_hint_locks = False
         elif self.options.GameMode == self.options.GameMode.option_open_sector_hub:
@@ -163,6 +164,7 @@ class MetroidFusionWorld(World):
                 self.starting_location_object = sector_hub
             self.starting_major_upgrades = 1
             self.starting_energy_tanks = 1
+            self.filler_items = None
             self.open_sector_elevators = True
             self.navigation_room_hint_locks = True
         elif self.options.GameMode == self.options.GameMode.option_custom:
@@ -185,6 +187,7 @@ class MetroidFusionWorld(World):
                     self.starting_location_object = main_deck_hub
             self.starting_major_upgrades = self.options.StartingMajorUpgrades.value
             self.starting_energy_tanks = self.options.StartingEnergyTanks.value
+            self.filler_items = self.options.FillerItems.value
             self.open_sector_elevators = bool(self.options.OpenSectorElevators.value)
             self.navigation_room_hint_locks = bool(self.options.SectorNavigationRoomHintLocks.value)
 
@@ -886,6 +889,8 @@ class MetroidFusionWorld(World):
         if self.filler_items is None:
             self.filler_items = [item for item in item_table if
                                  item_table[item].classification == ItemClassification.filler]
+        if len(self.filler_items) == 0:
+            self.filler_items = ["Nothing"]
         return self.random.choice(self.filler_items)
 
     def fill_slot_data(self) -> Dict[str, Any]:


### PR DESCRIPTION
## What is this fixing or adding?

Adds support for configuring the filler items used when the Game Mode is set to custom.

Also fixes a latent bug when there was no item classified as filler.

## How was this tested?

Multiple games have been generated, using different sets of configuration options, all without any generation errors.

## If this makes graphical changes, please attach screenshots.

There are no Graphical Changes.